### PR TITLE
Do not error for simple search use cases without facets

### DIFF
--- a/lib/search-context.js
+++ b/lib/search-context.js
@@ -366,14 +366,16 @@ SearchContext.prototype.search = function (adhoc) {
     return resp.json()
   })
   .then(function (results) {
-    Object.keys(results.facets)
-    .forEach(function (name) {
-      var constraint = self.constraints[name]
+    if (results.facets) {
+      Object.keys(results.facets)
+      .forEach(function (name) {
+        var constraint = self.constraints[name]
 
-      if (constraint) {
-        constraint.facet = results.facets[name]
-      }
-    })
+        if (constraint) {
+          constraint.facet = results.facets[name]
+        }
+      })
+    }
 
     return results
   })


### PR DESCRIPTION
I'm putting your code to use as I spike on creating reusable components built with React / Redux. Ran into this: If you don't specify facets in your search options, no data.facets array gets returned by MarkLogic.